### PR TITLE
[追加]ClientVPNを相互認証で実装

### DIFF
--- a/client-vpn/README.md
+++ b/client-vpn/README.md
@@ -1,0 +1,2 @@
+# aws-cloudformation
+A simple sample of CloudFormation.

--- a/client-vpn/add-route-table-cfn.yml
+++ b/client-vpn/add-route-table-cfn.yml
@@ -1,0 +1,43 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description:
+  Add a route table to ClientVPN.
+  For example, this can be useful to access other subnets that are VPC peering.
+  It can also be useful for controlling browsing to certain websites, but 0.0.0.0/0 is prohibited.
+
+Parameters:
+  SubnetID1:
+    Type: "AWS::EC2::Subnet::Id"
+    Description: Select at private subnet in your selected VPC.
+  SubnetID2:
+    Type: "AWS::EC2::Subnet::Id"
+    Description: Select at private subnet in your selected VPC.
+  AccessRage1:
+    Type: String
+    Description: "Range of routes to be accessed from the VPN. (SubnetID1)"
+    Default: "172.17.0.0/16"
+  AccessRage2:
+    Type: String
+    Description: "Range of routes to be accessed from the VPN. (SubnetID2)"
+    Default: "172.17.0.0/16"
+
+Resources:
+  # ルートテーブルの設定 
+  RangeAccessRoute1:
+    Type: "AWS::EC2::ClientVpnRoute"
+    Properties:
+      # create-clientvpn-cfn.ymlで作成したエンドポイントに対してルートテーブルを追加
+      ClientVpnEndpointId: !ImportValue ClientVpnEndpoint
+      # 対象のサブネットを指定
+      TargetVpcSubnetId: 
+        Ref: SubnetID1
+      # 向き先のCIDRブロックを指定
+      DestinationCidrBlock: !Ref AccessRage1
+      Description: "SubnetID1 Access Route Table."
+  RangeAccessRoute2:
+    Type: "AWS::EC2::ClientVpnRoute"
+    Properties:
+      ClientVpnEndpointId: !ImportValue ClientVpnEndpoint
+      TargetVpcSubnetId: 
+        Ref: SubnetID2
+      DestinationCidrBlock: !Ref AccessRage2
+      Description: "SubnetID2 Access Route Table."

--- a/client-vpn/create-clientvpn-cfn.yml
+++ b/client-vpn/create-clientvpn-cfn.yml
@@ -1,0 +1,107 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description:
+  This is a template of how to start ClientVPN from the official AWS documentation.
+  https://docs.aws.amazon.com/ja_jp/vpn/latest/clientvpn-admin/cvpn-getting-started.html
+
+Parameters:
+  ServerCertificateARN:
+    Type: String
+    Default: "arn:aws:acm:ap-northeast-1:{AWSAccountID}:certificate/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  ClientCertificateARN:
+    Type: String
+    Default: "arn:aws:acm:ap-northeast-1:{AWSAccountID}:certificate/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  ClientCIDR:
+    Type: String
+    Description: "Enter the CIDR block. Specify with xxx.xxx.xxx.x/22"
+    Default: "10.0.0.0/22"
+  VPCID:
+    Type: "AWS::EC2::VPC::Id"
+    Description: Select at your VPC.
+  SubnetID1:
+    Type: "AWS::EC2::Subnet::Id"
+    Description: Select at private subnet in your selected VPC.
+  SubnetID2:
+    Type: "AWS::EC2::Subnet::Id"
+    Description: Select at private subnet in your selected VPC.
+
+Resources:
+  ClientVpnEndpoint: 
+    Type: AWS::EC2::ClientVpnEndpoint
+    Properties: 
+      Description: "Client VPN Endpoint."
+      # クライアント認証の形式
+      AuthenticationOptions: 
+        - Type: certificate-authentication
+          MutualAuthentication:
+            ClientRootCertificateChainArn: !Ref ClientCertificateARN
+      # ClientVPNのCIDR
+      ClientCidrBlock: !Ref ClientCIDR
+      # ログの設定
+      ConnectionLogOptions: 
+        Enabled: true
+        CloudwatchLogGroup: !Ref LogGroup
+      # ClientVPNに関連付けるセキュリティグループ
+      SecurityGroupIds: 
+        - !Ref VpnSecurityGroup
+      # コマンドで作成したサーバー証明書
+      ServerCertificateArn: !Ref ServerCertificateARN
+      # 全ての通信がClientVPN経由にならないように制御する(0.0.0.0/0のルートテーブルも無視する)
+      SplitTunnel: true
+      # VPNで使用するトランスポートプロトコル
+      TransportProtocol: udp
+      # 対象のVPC
+      VpcId: !Ref VPCID
+      # VPNで利用するポート番号(443 or 1194)
+      VpnPort: 1194
+
+  # アソシエーションの追加
+  NetworkAssociation1:
+    Type: "AWS::EC2::ClientVpnTargetNetworkAssociation"
+    Properties:
+      ClientVpnEndpointId: !Ref ClientVpnEndpoint
+      SubnetId: 
+        Ref: SubnetID1
+  NetworkAssociation2:
+    Type: "AWS::EC2::ClientVpnTargetNetworkAssociation"
+    Properties:
+      ClientVpnEndpointId: !Ref ClientVpnEndpoint
+      SubnetId: 
+        Ref: SubnetID2
+
+  # 認証設定の追加
+  AuthRule:
+    Type: "AWS::EC2::ClientVpnAuthorizationRule"
+    Properties:
+      ClientVpnEndpointId: !Ref ClientVpnEndpoint
+      # 全ての認証を許可する
+      AuthorizeAllGroups: true
+      TargetNetworkCidr: "0.0.0.0/0"
+      Description: "Authoriza All Access."
+
+  # ロググループの作成
+  LogGroup: 
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      RetentionInDays: 365
+
+  # セキュリティグループの作成
+  VpnSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: client-vpn
+      GroupDescription: client-vpn
+      VpcId: !Ref VPCID
+      Tags:
+        - Key: Name
+          Value: client-vpn
+
+# 別のスタックで利用するためにOutputしておく
+Outputs:
+  ClientVpnEndpoint:
+    Value: !Ref ClientVpnEndpoint
+    Export:
+      Name: ClientVpnEndpoint
+  VpnSecurityGroup:
+    Value: !Ref VpnSecurityGroup
+    Export:
+      Name: VpnSecurityGroup


### PR DESCRIPTION
## 概要
- AWS ClientVPNエンドポイントを作成するテンプレート。
- 事前準備として[相互証明書](https://docs.aws.amazon.com/ja_jp/vpn/latest/clientvpn-admin/client-authentication.html#mutual)の発行が必要。
- ルートテーブルにルーティングを追加できるように

## 関連URL
- https://docs.aws.amazon.com/ja_jp/vpn/latest/clientvpn-admin/cvpn-getting-started.html
- https://noname.work/2949.html